### PR TITLE
feat: Community API 연동

### DIFF
--- a/src/api/formatDate.js
+++ b/src/api/formatDate.js
@@ -1,9 +1,28 @@
-const formatDate = (timestamp) => {
+const formatDate = (timestamp, useCase) => {
   const date = new Date(timestamp);
-  const year = String(date.getFullYear()).slice(-2);
+
+  let year;
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
+  const timeMatch = timestamp?.match(/T(\d{2}:\d{2})/);
+  const time = timeMatch ? timeMatch[1] : '';
+
+  switch (useCase) {
+    case 1:
+      year = String(date.getFullYear()).slice(-2);
+      return `${year}.${month}.${day} ${time}`;
+
+    case 2:
+      year = String(date.getFullYear());
+      return `${year}.${month}.${day} ${time}`;
+
+    case 3:
+      year = String(date.getFullYear()).slice(-2);
+      return `${year}.${month}.${day}`;
+
+    default:
+      return 0;
+  }
 };
 
 export default formatDate;

--- a/src/components/Comunity/CommunityList.jsx
+++ b/src/components/Comunity/CommunityList.jsx
@@ -12,11 +12,11 @@ const CommunityList = ({ list }) => {
   const navigate = useNavigate();
 
   const { data: post, isLoading, isError } = useFetchList(list.postId);
+  const { data: com } = useFetchList(list.postId, 1);
+  console.log(com);
 
-  console.log(post);
-
-  const handleNavigate = (data) => {
-    navigate(`/community/${data.postId}`, { state: { selectedPost: data } });
+  const handleNavigate = (temp) => {
+    navigate(`/community/${temp.postId}`, { state: { selectedPost: temp } });
   };
 
   return (

--- a/src/components/Comunity/CommunityList.jsx
+++ b/src/components/Comunity/CommunityList.jsx
@@ -13,7 +13,6 @@ const CommunityList = ({ list }) => {
 
   const { data: post, isLoading, isError } = useFetchList(list.postId);
   const { data: com } = useFetchList(list.postId, 1);
-  console.log(com);
 
   const handleNavigate = (temp) => {
     navigate(`/community/${temp.postId}`, { state: { selectedPost: temp } });

--- a/src/components/Comunity/CommunityList.jsx
+++ b/src/components/Comunity/CommunityList.jsx
@@ -6,39 +6,42 @@ import ImageDescript from '../../assets/Search/imageDescript.svg';
 import CommentPhoto from '../../assets/Community/CommentPhoto.svg';
 
 import formatDate from '../../api/formatDate';
-import CommunityComment from '../../store/community/CommunityComment';
+import useFetchList from '../../hooks/useFetchList';
 
 const CommunityList = ({ list }) => {
   const navigate = useNavigate();
-  const comment = CommunityComment.filter((num) => num.post_id === list.id);
 
-  const handleNavigate = (list) => {
-    navigate(`/community/${list.id}`, { state: { selectedPost: list } });
+  const { data: post, isLoading, isError } = useFetchList(list.postId);
+
+  console.log(post);
+
+  const handleNavigate = (data) => {
+    navigate(`/community/${data.postId}`, { state: { selectedPost: data } });
   };
 
   return (
     <ListContainer>
-      <NoList>{list.id}</NoList>
-      {list.image.length ? (
+      <NoList>{list?.postId}</NoList>
+      {post?.data.images.length ? (
         <ImageYes src={ImageDescript} alt={'그림있으요'} />
       ) : (
         <ImageNo />
       )}
-      <TitleList onClick={() => handleNavigate(list)}>
-        {list.title}
-        {comment ? (
+      <TitleList onClick={() => handleNavigate(post.data)}>
+        {post?.data.title}
+        {post?.data.commentCount > 0 ? (
           <>
             <ViewDescript src={CommentPhoto} alt={'댓글있으요'} />
-            <ViewPeople>{comment.length}</ViewPeople>
+            <ViewPeople>{post?.data.commentCount}</ViewPeople>
           </>
         ) : (
           ''
         )}
       </TitleList>
       <DateList>
-        <DateList>{formatDate(list.created_at)}</DateList>
+        <DateList>{formatDate(post?.data.createdAt)}</DateList>
       </DateList>
-      <SeeList>{list.views}</SeeList>
+      <SeeList>100</SeeList>
     </ListContainer>
   );
 };
@@ -114,14 +117,14 @@ const ViewPeople = styled.div`
 
 const DateList = styled.span`
   display: inline-flex;
-  width: 95px;
+  width: 100px;
   margin-left: 25px;
   text-align: center;
 `;
 
 const SeeList = styled.span`
   display: inline-block;
-  margin-left: 48px;
+  margin-left: 40px;
   width: 65px;
   text-align: center;
 `;

--- a/src/components/Comunity/CommunityList.jsx
+++ b/src/components/Comunity/CommunityList.jsx
@@ -12,7 +12,6 @@ const CommunityList = ({ list }) => {
   const navigate = useNavigate();
 
   const { data: post, isLoading, isError } = useFetchList(list.postId);
-  const { data: com } = useFetchList(list.postId, 1);
 
   const handleNavigate = (temp) => {
     navigate(`/community/${temp.postId}`, { state: { selectedPost: temp } });

--- a/src/components/Comunity/CommunityList.jsx
+++ b/src/components/Comunity/CommunityList.jsx
@@ -37,7 +37,7 @@ const CommunityList = ({ list }) => {
         )}
       </TitleList>
       <DateList>
-        <DateList>{formatDate(post?.data.createdAt)}</DateList>
+        <DateList>{formatDate(post?.data.createdAt, 3)}</DateList>
       </DateList>
     </ListContainer>
   );
@@ -118,7 +118,7 @@ const ViewPeople = styled.div`
 const DateList = styled.span`
   display: inline-flex;
   width: 100px;
-  margin-left: 25px;
+  margin-left: 27px;
   text-align: center;
 `;
 

--- a/src/components/Comunity/CommunityList.jsx
+++ b/src/components/Comunity/CommunityList.jsx
@@ -39,20 +39,22 @@ const CommunityList = ({ list }) => {
       <DateList>
         <DateList>{formatDate(post?.data.createdAt)}</DateList>
       </DateList>
-      <SeeList>100</SeeList>
     </ListContainer>
   );
 };
 
 const ListContainer = styled.div`
   margin-top: 16px;
-  margin-left: 37px;
+  margin-left: 60px;
   height: 20px;
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
   color: white;
+
+  display: flex;
+  align-items: center;
 `;
 
 const NoList = styled.span`
@@ -82,7 +84,7 @@ const ImageNo = styled.div`
 const TitleList = styled.button`
   display: inline-flex;
   margin-left: 5px;
-  width: 627px;
+  width: 668px;
   text-align: start;
   border: 0;
   background-color: transparent;
@@ -117,13 +119,6 @@ const DateList = styled.span`
   display: inline-flex;
   width: 100px;
   margin-left: 25px;
-  text-align: center;
-`;
-
-const SeeList = styled.span`
-  display: inline-block;
-  margin-left: 40px;
-  width: 65px;
   text-align: center;
 `;
 

--- a/src/components/Comunity/CommunityLists.jsx
+++ b/src/components/Comunity/CommunityLists.jsx
@@ -4,16 +4,20 @@ import styled from 'styled-components';
 
 import Pagination from '../../components/Pagination';
 import CommunityList from './CommunityList';
+import useFetchList from '../../hooks/useFetchList';
 
 const CommunityLists = () => {
   const navigate = useNavigate();
+
+  const { data, isLoading, isError } = useFetchList();
+  console.log(data);
 
   const { filteredList, currentPage, perData, setCurrentPage, CommunityPost } =
     useOutletContext();
 
   return (
     <ListsContainer>
-      {filteredList?.map((list) => (
+      {data?.data.posts.map((list) => (
         <CommunityList list={list} />
       ))}
       <PaginationContainer>

--- a/src/components/Comunity/CommunityLists.jsx
+++ b/src/components/Comunity/CommunityLists.jsx
@@ -10,7 +10,6 @@ const CommunityLists = () => {
   const navigate = useNavigate();
 
   const { data, isLoading, isError } = useFetchList();
-  console.log(data);
 
   const { filteredList, currentPage, perData, setCurrentPage, CommunityPost } =
     useOutletContext();

--- a/src/components/Comunity/EditFooter.jsx
+++ b/src/components/Comunity/EditFooter.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import SingleBtnAlert from '../SingleBtnAlert';
 import ConfirmLeaveAlert from '../ConfirmLeaveAlert';
 import axiosInstance from '../../api/axios-instance';
+import FetchImage from '../../hooks/FetchImage';
 
 const EditFooter = ({
   handleFileChange,
@@ -19,6 +20,12 @@ const EditFooter = ({
   const handleSubmit = async () => {
     if (!content || !title) setShowInvalidAlert(true);
     else {
+      try {
+        FetchImage(fileName);
+      } catch (error) {
+        console.log(error);
+      }
+
       const postData = {
         title: title,
         content: content,

--- a/src/components/Comunity/EditFooter.jsx
+++ b/src/components/Comunity/EditFooter.jsx
@@ -5,7 +5,13 @@ import SingleBtnAlert from '../SingleBtnAlert';
 import ConfirmLeaveAlert from '../ConfirmLeaveAlert';
 import axiosInstance from '../../api/axios-instance';
 
-const EditFooter = ({ handleFileChange, content, title, fileName }) => {
+const EditFooter = ({
+  handleFileChange,
+  content,
+  title,
+  fileName,
+  selectedPost
+}) => {
   const navigate = useNavigate();
   const [showInvalidAlert, setShowInvalidAlert] = useState(false);
   const [showCancelAlert, setShowCancelAlert] = useState(false);
@@ -20,7 +26,13 @@ const EditFooter = ({ handleFileChange, content, title, fileName }) => {
       };
 
       try {
-        const response = await axiosInstance.post(`/community/posts`, postData);
+        if (selectedPost) {
+          const response = await axiosInstance.put(
+            `/community/posts/${selectedPost.postId}`,
+            postData
+          );
+          console.log(response);
+        } else await axiosInstance.post(`/community/posts`, postData);
       } catch (error) {
         console.log(error);
       }

--- a/src/components/Comunity/EditFooter.jsx
+++ b/src/components/Comunity/EditFooter.jsx
@@ -31,7 +31,6 @@ const EditFooter = ({
             `/community/posts/${selectedPost.postId}`,
             postData
           );
-          console.log(response);
         } else await axiosInstance.post(`/community/posts`, postData);
       } catch (error) {
         console.log(error);

--- a/src/components/Comunity/EditFooter.jsx
+++ b/src/components/Comunity/EditFooter.jsx
@@ -3,15 +3,27 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import SingleBtnAlert from '../SingleBtnAlert';
 import ConfirmLeaveAlert from '../ConfirmLeaveAlert';
+import axiosInstance from '../../api/axios-instance';
 
 const EditFooter = ({ handleFileChange, content, title, fileName }) => {
   const navigate = useNavigate();
   const [showInvalidAlert, setShowInvalidAlert] = useState(false);
   const [showCancelAlert, setShowCancelAlert] = useState(false);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!content || !title) setShowInvalidAlert(true);
     else {
+      const postData = {
+        title: title,
+        content: content,
+        images: fileName ? fileName : []
+      };
+
+      try {
+        const response = await axiosInstance.post(`/community/posts`, postData);
+      } catch (error) {
+        console.log(error);
+      }
       navigate('/community');
     }
   };

--- a/src/components/Comunity/ListTopBar.jsx
+++ b/src/components/Comunity/ListTopBar.jsx
@@ -7,38 +7,38 @@ const ListTopBar = () => {
       <No>No</No>
       <Title>제목</Title>
       <WriteDate>작성일</WriteDate>
-      <See>조회수</See>
     </TopBorder>
   );
 };
 
 const TopBorder = styled.div`
-  height: 37px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  height: 50px;
   border-bottom: 7px solid #9819c3;
   background-color: #000;
   font-size: 22px;
-  font-style: normal;
-  font-weight: 660;
-  line-height: normal;
+  font-weight: bold;
   color: white;
 `;
 
 const No = styled.span`
-  width: 30px;
-  height: 26px;
-  padding-left: 34px;
+  flex: 1;
+  text-align: left;
+  padding-left: 40px;
 `;
 
 const Title = styled.span`
-  margin-left: 380px;
+  flex: 3;
+  text-align: center;
 `;
 
 const WriteDate = styled.span`
-  margin-left: 370px;
-`;
-
-const See = styled.span`
-  margin-left: 54px;
+  flex: 1;
+  text-align: right;
+  padding-right: 40px;
 `;
 
 export default ListTopBar;

--- a/src/components/Comunity/PostComment.jsx
+++ b/src/components/Comunity/PostComment.jsx
@@ -23,7 +23,7 @@ const PostComment = ({ comment, postId, user }) => {
       <CommentProfile>
         <CommentImage src={comment.userProfileImage} alt="프로필 이미지" />
         <CommentDetails>
-          <CommentDate>{formatDate(comment.createdAt)}</CommentDate>
+          <CommentDate>{formatDate(comment.createdAt, 2)}</CommentDate>
           <CommentAuthor>{comment.userName}</CommentAuthor>
         </CommentDetails>
         {user?.data.nickname == comment.userName &&

--- a/src/components/Comunity/PostComment.jsx
+++ b/src/components/Comunity/PostComment.jsx
@@ -9,13 +9,10 @@ const PostComment = ({ comment }) => {
   return (
     <Comment>
       <CommentProfile>
-        <CommentImage
-          src="https://via.placeholder.com/50"
-          alt="프로필 이미지"
-        />
+        <CommentImage src={comment.userProfileImage} alt="프로필 이미지" />
         <CommentDetails>
-          <CommentDate>{formatDate(comment.created_at)}</CommentDate>
-          <CommentAuthor>{comment.user_id}</CommentAuthor>
+          <CommentDate>{formatDate(comment.createdAt)}</CommentDate>
+          <CommentAuthor>{comment.userName}</CommentAuthor>
         </CommentDetails>
         {true ? (
           <ReportButton src={Alert} alt={'그럴리없다'} />

--- a/src/components/Comunity/PostComment.jsx
+++ b/src/components/Comunity/PostComment.jsx
@@ -7,14 +7,14 @@ import Alert from '../../assets/Community/SirenButton.svg';
 
 import axiosInstacne from '../../api/axios-instance';
 
-const PostComment = ({ comment, postId }) => {
+const PostComment = ({ comment, postId, user }) => {
   const handleDelete = async () => {
     try {
       await axiosInstacne.delete(
         `/community/posts/${postId}/comments/${comment.commentId}`
       );
     } catch (error) {
-      console.log(error);
+      alert(error);
     }
   };
 
@@ -26,14 +26,15 @@ const PostComment = ({ comment, postId }) => {
           <CommentDate>{formatDate(comment.createdAt)}</CommentDate>
           <CommentAuthor>{comment.userName}</CommentAuthor>
         </CommentDetails>
-        {false ? (
-          <ReportButton src={Alert} alt={'그럴리없다'} />
-        ) : (
+        {user.data.nickname == comment.userName &&
+        user.data.profileImage == comment.userProfileImage ? (
           <ButtonContainer
             src={Delete}
             alt={'그럴리없다'}
             onClick={() => handleDelete()}
           />
+        ) : (
+          <ReportButton src={Alert} alt={'그럴리없다'} />
         )}
       </CommentProfile>
       <CommentContent>{comment.content}</CommentContent>

--- a/src/components/Comunity/PostComment.jsx
+++ b/src/components/Comunity/PostComment.jsx
@@ -26,8 +26,8 @@ const PostComment = ({ comment, postId, user }) => {
           <CommentDate>{formatDate(comment.createdAt)}</CommentDate>
           <CommentAuthor>{comment.userName}</CommentAuthor>
         </CommentDetails>
-        {user.data.nickname == comment.userName &&
-        user.data.profileImage == comment.userProfileImage ? (
+        {user?.data.nickname == comment.userName &&
+        user?.data.profileImage == comment.userProfileImage ? (
           <ButtonContainer
             src={Delete}
             alt={'그럴리없다'}

--- a/src/components/Comunity/PostComment.jsx
+++ b/src/components/Comunity/PostComment.jsx
@@ -5,7 +5,19 @@ import formatDate from '../../api/formatDate';
 import Delete from '../../assets/Community/DeleteButton.svg';
 import Alert from '../../assets/Community/SirenButton.svg';
 
-const PostComment = ({ comment }) => {
+import axiosInstacne from '../../api/axios-instance';
+
+const PostComment = ({ comment, postId }) => {
+  const handleDelete = async () => {
+    try {
+      await axiosInstacne.delete(
+        `/community/posts/${postId}/comments/${comment.commentId}`
+      );
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <Comment>
       <CommentProfile>
@@ -14,10 +26,14 @@ const PostComment = ({ comment }) => {
           <CommentDate>{formatDate(comment.createdAt)}</CommentDate>
           <CommentAuthor>{comment.userName}</CommentAuthor>
         </CommentDetails>
-        {true ? (
+        {false ? (
           <ReportButton src={Alert} alt={'그럴리없다'} />
         ) : (
-          <ButtonContainer src={Delete} alt={'그럴리없다'} />
+          <ButtonContainer
+            src={Delete}
+            alt={'그럴리없다'}
+            onClick={() => handleDelete()}
+          />
         )}
       </CommentProfile>
       <CommentContent>{comment.content}</CommentContent>

--- a/src/components/Comunity/PostContent.jsx
+++ b/src/components/Comunity/PostContent.jsx
@@ -11,14 +11,26 @@ import Delete from '../../assets/Community/DeleteButton.svg';
 import Alert from '../../assets/Community/SirenButton.svg';
 
 import ConfirmDeleteAlert from '../ConfirmDelete';
+import axiosInstance from '../../api/axios-instance';
 
 const PostContent = ({ comment, handleModal, selectedPost }) => {
   const navigate = useNavigate();
+
+  console.log(selectedPost);
 
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
 
   const handleDelete = () => {
     setShowConfirmDelete(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    try {
+      await axiosInstance.delete(`/community/posts/${selectedPost.postId}`);
+      navigate('/community');
+    } catch (error) {
+      console.error('게시글 삭제 실패:', error);
+    }
   };
 
   return (
@@ -86,6 +98,7 @@ const PostContent = ({ comment, handleModal, selectedPost }) => {
             </AlertText>
           }
           onClose={() => setShowConfirmDelete(false)}
+          onConfirm={handleDeleteConfirm}
           showButtons={true}
         />
       )}

--- a/src/components/Comunity/PostContent.jsx
+++ b/src/components/Comunity/PostContent.jsx
@@ -39,7 +39,7 @@ const PostContent = ({ comment, handleModal, selectedPost, user }) => {
           <TextContainer>{comment?.length || 0}</TextContainer>
         </PostStats>
         <PostMeta>
-          <span>작성일 : {formatDate(selectedPost?.createdAt)}</span>
+          <span>작성일 : {formatDate(selectedPost?.createdAt, 1)}</span>
         </PostMeta>
       </PostInfo>
       <PostInfo>

--- a/src/components/Comunity/PostContent.jsx
+++ b/src/components/Comunity/PostContent.jsx
@@ -15,7 +15,6 @@ import ConfirmDeleteAlert from '../ConfirmDelete';
 const PostContent = ({ comment, handleModal, selectedPost }) => {
   const navigate = useNavigate();
 
-  console.log(selectedPost);
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
 
   const handleDelete = () => {

--- a/src/components/Comunity/PostContent.jsx
+++ b/src/components/Comunity/PostContent.jsx
@@ -13,7 +13,7 @@ import Alert from '../../assets/Community/SirenButton.svg';
 import ConfirmDeleteAlert from '../ConfirmDelete';
 import axiosInstance from '../../api/axios-instance';
 
-const PostContent = ({ comment, handleModal, selectedPost }) => {
+const PostContent = ({ comment, handleModal, selectedPost, user }) => {
   const navigate = useNavigate();
 
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
@@ -45,7 +45,7 @@ const PostContent = ({ comment, handleModal, selectedPost }) => {
         </PostMeta>
       </PostInfo>
       <PostInfo>
-        {true ? (
+        {user?.data.nickname == selectedPost.author ? (
           <PostActions>
             <ButtonContainer
               onClick={() =>

--- a/src/components/Comunity/PostContent.jsx
+++ b/src/components/Comunity/PostContent.jsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import formatDate from '../../api/formatDate';
 
-import ViewPhoto from '../../assets/Community/ViewPhoto.svg';
 import CommentPhoto from '../../assets/Community/CommentPhoto.svg';
 import Edit from '../../assets/Community/EditButton.svg';
 import Delete from '../../assets/Community/DeleteButton.svg';
@@ -43,7 +42,7 @@ const PostContent = ({ comment, handleModal, selectedPost, user }) => {
         </PostMeta>
       </PostInfo>
       <PostInfo>
-        {user?.data.nickname == selectedPost.author ? (
+        {user?.data.nickname == selectedPost?.author ? (
           <PostActions>
             <ButtonContainer
               onClick={() =>

--- a/src/components/Comunity/PostContent.jsx
+++ b/src/components/Comunity/PostContent.jsx
@@ -35,10 +35,8 @@ const PostContent = ({ comment, handleModal, selectedPost, user }) => {
     <>
       <PostInfo>
         <PostStats>
-          <ViewContainer src={ViewPhoto} alt={'그럴리없다'} />
-          <TextContainer>{selectedPost?.views}</TextContainer>
           <ViewContainer src={CommentPhoto} alt={'그럴리없다'} />
-          <TextContainer>{comment?.length}</TextContainer>
+          <TextContainer>{comment?.length || 0}</TextContainer>
         </PostStats>
         <PostMeta>
           <span>작성일 : {formatDate(selectedPost?.createdAt)}</span>
@@ -131,6 +129,7 @@ const ViewContainer = styled.img`
   width: 28px;
   height: 28px;
 
+  margin-bottom: 5px;
   margin-right: 5px;
 `;
 

--- a/src/components/Comunity/PostContent.jsx
+++ b/src/components/Comunity/PostContent.jsx
@@ -16,8 +16,6 @@ import axiosInstance from '../../api/axios-instance';
 const PostContent = ({ comment, handleModal, selectedPost }) => {
   const navigate = useNavigate();
 
-  console.log(selectedPost);
-
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
 
   const handleDelete = () => {

--- a/src/components/Comunity/PostContent.jsx
+++ b/src/components/Comunity/PostContent.jsx
@@ -15,6 +15,7 @@ import ConfirmDeleteAlert from '../ConfirmDelete';
 const PostContent = ({ comment, handleModal, selectedPost }) => {
   const navigate = useNavigate();
 
+  console.log(selectedPost);
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
 
   const handleDelete = () => {
@@ -31,7 +32,7 @@ const PostContent = ({ comment, handleModal, selectedPost }) => {
           <TextContainer>{comment?.length}</TextContainer>
         </PostStats>
         <PostMeta>
-          <span>작성일 : {formatDate(selectedPost?.created_at)}</span>
+          <span>작성일 : {formatDate(selectedPost?.createdAt)}</span>
         </PostMeta>
       </PostInfo>
       <PostInfo>
@@ -42,28 +43,28 @@ const PostContent = ({ comment, handleModal, selectedPost }) => {
                 navigate('/community/edit', { state: { selectedPost } })
               }
               src={Edit}
-              alt={'그럴리없다'}
+              alt={'수정버튼'}
             />
             <ButtonContainer
               src={Delete}
-              alt={'그럴리없다'}
+              alt={'삭제버튼'}
               onClick={() => handleDelete()}
             />
           </PostActions>
         ) : (
           <PostActions>
-            <ReportButton src={Alert} alt={'그럴리없다'} />
+            <ReportButton src={Alert} alt={'신고버튼'} />
           </PostActions>
         )}
         <PostMeta>
-          <span>작성자 : {selectedPost?.user_id}</span>{' '}
+          <span>작성자 : {selectedPost?.author}</span>{' '}
         </PostMeta>
       </PostInfo>
       <Content>
         {selectedPost?.content}
-        {selectedPost?.image.length && (
+        {selectedPost?.images.length > 0 && (
           <ImageContainer>
-            {selectedPost?.image.map((img) => (
+            {selectedPost?.images.map((img) => (
               <Image
                 src={img}
                 alt={'이미지'}

--- a/src/components/ConfirmDelete.jsx
+++ b/src/components/ConfirmDelete.jsx
@@ -7,6 +7,7 @@ const ConfirmDeleteAlert = ({
   title,
   message,
   onClose,
+  onConfirm,
   messageColor,
   messagesize,
   mariginsize = '22.5px', //margin-top 설정
@@ -51,7 +52,7 @@ const ConfirmDeleteAlert = ({
         {/* 예 아니요 버튼 유무 true/false로 설정 */}
         {showButtons && (
           <Buttons>
-            <Leave to="/">{deleteLabel}</Leave>
+            <Leave onClick={onConfirm}>{deleteLabel}</Leave>
             <Stay onClick={handleClick}>{cancelLabel}</Stay>
           </Buttons>
         )}

--- a/src/hooks/FetchImage.js
+++ b/src/hooks/FetchImage.js
@@ -1,0 +1,19 @@
+import axiosInstance from '../api/axios-instance';
+
+const FetchImage = ({ images }) => {
+  const PostImage = async () => {
+    try {
+      console.log('여기까지도 왔음');
+      const fileExtensions = images.map(() => 'jpg').join('&fileExtensions=');
+      const response = await axiosInstance.post(
+        `/image/post?fileExtensions=${fileExtensions}`
+      );
+      console.log(response.data);
+    } catch (error) {
+      alert(error);
+    }
+    PostImage();
+  };
+};
+
+export default FetchImage;

--- a/src/hooks/useFetchList.js
+++ b/src/hooks/useFetchList.js
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+import axiosInstance from '../api/axios-instance';
+
+const useFetchList = (postId) => {
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true);
+      setIsError(false);
+
+      try {
+        let url = '';
+
+        if (postId) {
+          url = `/community/posts/${postId}`;
+        } else {
+          url = '/community/posts';
+        }
+
+        const response = await axiosInstance.get(url);
+        setData(response.data);
+      } catch (error) {
+        setIsError(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [postId]);
+
+  return { data, isLoading, isError };
+};
+
+export default useFetchList;

--- a/src/hooks/useFetchList.js
+++ b/src/hooks/useFetchList.js
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import axiosInstance from '../api/axios-instance';
 
-const useFetchList = (postId) => {
+const useFetchList = (postId, comment) => {
   const [data, setData] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
 
   useEffect(() => {
+    if (comment === 1 && !postId) return;
+
     const fetchData = async () => {
       setIsLoading(true);
       setIsError(false);
@@ -14,9 +16,18 @@ const useFetchList = (postId) => {
       try {
         let url = '';
 
-        if (postId) {
+        // post 댓글 조회
+        if (comment === 1 && postId) {
+          url = `/community/posts/${postId}/comments`;
+        }
+
+        // 단일 post 조회
+        else if (postId) {
           url = `/community/posts/${postId}`;
-        } else {
+        }
+
+        // post 목록 조회
+        else {
           url = '/community/posts';
         }
 
@@ -30,7 +41,7 @@ const useFetchList = (postId) => {
     };
 
     fetchData();
-  }, [postId]);
+  }, [postId, comment]);
 
   return { data, isLoading, isError };
 };

--- a/src/hooks/useGet.js
+++ b/src/hooks/useGet.js
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+import axiosInstance from '../api/axios-instance';
+
+const useGet = () => {
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true);
+      setIsError(false);
+
+      try {
+        const response = await axiosInstance.get(`/users/me`);
+        setData(response.data);
+      } catch (error) {
+        setIsError(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return { data, isLoading, isError };
+};
+
+export default useGet;

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -4,9 +4,13 @@ import styled from 'styled-components';
 import Topbar from '../components/Topbar';
 import Footer from '../components/Footer';
 
+import useGet from '../hooks/useGet';
+
 const MainLayout = () => {
   const navigate = useNavigate();
   const [token, setToken] = useState(() => localStorage.getItem('token'));
+
+  const { data: user } = useGet();
 
   useEffect(() => {
     const handleStorageChange = () => {
@@ -28,7 +32,11 @@ const MainLayout = () => {
     <>
       <Container>
         <Topbar onSearch={handleSearch} token={token} />
-        <Outlet />
+        <Outlet
+          context={{
+            user
+          }}
+        />
         <Footer />
       </Container>
     </>

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -4,13 +4,9 @@ import styled from 'styled-components';
 import Topbar from '../components/Topbar';
 import Footer from '../components/Footer';
 
-import useGet from '../hooks/useGet';
-
 const MainLayout = () => {
   const navigate = useNavigate();
   const [token, setToken] = useState(() => localStorage.getItem('token'));
-
-  const { data: user } = useGet();
 
   useEffect(() => {
     const handleStorageChange = () => {
@@ -32,11 +28,7 @@ const MainLayout = () => {
     <>
       <Container>
         <Topbar onSearch={handleSearch} token={token} />
-        <Outlet
-          context={{
-            user
-          }}
-        />
+        <Outlet />
         <Footer />
       </Container>
     </>

--- a/src/pages/Community/CommunityEdit.jsx
+++ b/src/pages/Community/CommunityEdit.jsx
@@ -56,6 +56,7 @@ const CommunityEdit = () => {
           title={title}
           content={content}
           fileName={fileName}
+          selectedPost={selectedPost}
         />
       </ContentContainer>
     </Container>

--- a/src/pages/Community/CommunityPostPage.jsx
+++ b/src/pages/Community/CommunityPostPage.jsx
@@ -98,7 +98,7 @@ const CommunityPostPage = () => {
           />
           <CommentSection>
             {com?.data.comments.map((comment) => (
-              <PostComment comment={comment} />
+              <PostComment comment={comment} postId={selectedPost.postId} />
             ))}
             <PaginationContainer>
               <Pagination

--- a/src/pages/Community/CommunityPostPage.jsx
+++ b/src/pages/Community/CommunityPostPage.jsx
@@ -22,7 +22,7 @@ const CommunityPostPage = () => {
     data: com,
     isLoading,
     isError
-  } = useFetchList(selectedPost.postId, 1);
+  } = useFetchList(selectedPost?.postId, 1);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [commentCaution, setCommentCaution] = useState(true);
@@ -35,13 +35,6 @@ const CommunityPostPage = () => {
   const handleModal = (imgUrl) => {
     setImgUrl(imgUrl);
     setIsModalOpen(true);
-  };
-
-  const handleCommentChange = (e) => {
-    setCommentText(e.target.value);
-    if (e.target.value.length > 200 || e.target.value.length === 0)
-      setCommentCaution(true);
-    else setCommentCaution(false);
   };
 
   const handleCaution = (e) => {

--- a/src/pages/Community/CommunityPostPage.jsx
+++ b/src/pages/Community/CommunityPostPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, useOutletContext } from 'react-router-dom';
 import styled from 'styled-components';
 import ImageModal from '../../components/Comunity/ImageModal';
 import PostComment from '../../components/Comunity/PostComment';
@@ -9,6 +9,7 @@ import Pagination from '../../components/Pagination';
 import ConfirmLeaveAlert from '../../components/ConfirmLeaveAlert';
 import useFetchList from '../../hooks/useFetchList';
 import axiosInstance from '../../api/axios-instance';
+import useGet from '../../hooks/useGet';
 
 const CommunityPostPage = () => {
   const [comments, setComments] = useState([]);
@@ -18,6 +19,7 @@ const CommunityPostPage = () => {
 
   // 게시물 정보 가져오기
   const { selectedPost } = location.state || {};
+  const { data: user } = useGet();
 
   // 댓글 가져오기
   const {
@@ -25,8 +27,6 @@ const CommunityPostPage = () => {
     isLoading,
     isError
   } = useFetchList(selectedPost?.postId, 1);
-
-  console.log(com);
 
   useEffect(() => {
     if (com?.data?.comments) {
@@ -95,10 +95,15 @@ const CommunityPostPage = () => {
             comment={com?.data.comments}
             handleModal={handleModal}
             selectedPost={selectedPost}
+            user={user}
           />
           <CommentSection>
             {com?.data.comments.map((comment) => (
-              <PostComment comment={comment} postId={selectedPost.postId} />
+              <PostComment
+                comment={comment}
+                postId={selectedPost.postId}
+                user={user}
+              />
             ))}
             <PaginationContainer>
               <Pagination

--- a/src/pages/Community/CommunityPostPage.jsx
+++ b/src/pages/Community/CommunityPostPage.jsx
@@ -8,11 +8,21 @@ import PostContent from '../../components/Comunity/PostContent';
 import Pagination from '../../components/Pagination';
 
 import ConfirmLeaveAlert from '../../components/ConfirmLeaveAlert';
+import useFetchList from '../../hooks/useFetchList';
 
 const CommunityPostPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
+
+  // 게시물 정보 가져오기
   const { selectedPost } = location.state || {};
+
+  // 댓글 가져오기
+  const {
+    data: com,
+    isLoading,
+    isError
+  } = useFetchList(selectedPost.postId, 1);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [commentCaution, setCommentCaution] = useState(true);
@@ -48,16 +58,8 @@ const CommunityPostPage = () => {
     else navigate('/community');
   };
 
-  const comment = CommunityComment.filter(
-    (num) => num.post_id === selectedPost?.id
-  );
-
   const [currentPage, setCurrentPage] = useState(1);
   const perData = 10;
-  const filteredComment = comment.slice(
-    perData * (currentPage - 1),
-    perData * currentPage
-  );
 
   return (
     <>
@@ -67,17 +69,17 @@ const CommunityPostPage = () => {
             <div>{selectedPost?.title}</div>
           </PostHeader>
           <PostContent
-            comment={comment}
+            comment={com?.data.comments}
             handleModal={handleModal}
             selectedPost={selectedPost}
           />
           <CommentSection>
-            {filteredComment?.map((comment) => (
+            {com?.data.comments.map((comment) => (
               <PostComment comment={comment} />
             ))}
             <PaginationContainer>
               <Pagination
-                dataLength={comment.length}
+                dataLength={10}
                 perData={perData}
                 currentPage={currentPage}
                 setCurrentPage={setCurrentPage}

--- a/src/pages/Community/CommunityPostPage.jsx
+++ b/src/pages/Community/CommunityPostPage.jsx
@@ -21,6 +21,7 @@ const CommunityPostPage = () => {
   const { selectedPost } = location.state || {};
   const { data: user } = useGet();
 
+  console.log(selectedPost);
   // 댓글 가져오기
   const {
     data: com,

--- a/src/pages/Community/CommunityPostPage.jsx
+++ b/src/pages/Community/CommunityPostPage.jsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import CommunityComment from '../../store/community/CommunityComment';
 import ImageModal from '../../components/Comunity/ImageModal';
 import PostComment from '../../components/Comunity/PostComment';
 import PostContent from '../../components/Comunity/PostContent';
@@ -9,8 +8,11 @@ import Pagination from '../../components/Pagination';
 
 import ConfirmLeaveAlert from '../../components/ConfirmLeaveAlert';
 import useFetchList from '../../hooks/useFetchList';
+import axiosInstance from '../../api/axios-instance';
 
 const CommunityPostPage = () => {
+  const [comments, setComments] = useState([]);
+
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -24,8 +26,15 @@ const CommunityPostPage = () => {
     isError
   } = useFetchList(selectedPost?.postId, 1);
 
+  console.log(com);
+
+  useEffect(() => {
+    if (com?.data?.comments) {
+      setComments(com.data.comments);
+    }
+  }, [com]);
+
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [commentCaution, setCommentCaution] = useState(true);
   const [showCancelAlert, setShowCancelAlert] = useState(false);
 
   const [imgUrl, setImgUrl] = useState('');
@@ -49,6 +58,27 @@ const CommunityPostPage = () => {
   const handleCancel = () => {
     if (commentText) setShowCancelAlert(true);
     else navigate('/community');
+  };
+
+  const handleCommentSubmit = async () => {
+    if (!commentText.trim()) return;
+
+    const postData = {
+      content: commentText
+    };
+
+    try {
+      const response = await axiosInstance.post(
+        `/community/posts/${selectedPost.postId}/comments`,
+        postData
+      );
+
+      setComments((prevComments) => [response.data, ...prevComments]);
+
+      setCommentText('');
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   const [currentPage, setCurrentPage] = useState(1);
@@ -88,7 +118,7 @@ const CommunityPostPage = () => {
               {cautionText ? (
                 <inactivebutton>작성</inactivebutton>
               ) : (
-                <button>작성</button>
+                <button onClick={() => handleCommentSubmit()}>작성</button>
               )}
             </CommentInput>
             <CautionContainer> {cautionText || '\u00A0'}</CautionContainer>

--- a/src/pages/CommunityPage.jsx
+++ b/src/pages/CommunityPage.jsx
@@ -19,7 +19,7 @@ const Container = styled.div`
   height: 488px;
   background-color: black;
   justify-items: center;
-  padding: 73px 204px 184px 206px;
+  padding: 20px 204px 180px 206px;
 `;
 
 const ContentContainer = styled.div`


### PR DESCRIPTION
## 💡 연관된 이슈
#91 

## 📝 작업 내용
**현재 나와있는 모든 Community API 연동 완료 했습니담**

검색과는 다르게 로직이 간단하여 실제로 코드 짜는것도 꽤 많이 수월했습니다
아직 남은 문제는 다음과 같습니다

---
### 1. 게시글에 댓글이 남아 있을 경우 게시글 삭제가 안됨

이 부분은 이미 장원이랑 얘기 나눠서 API 수정 혹은 추가해준다고 했음!
그리고 해시태그도 이때 추가 되면 그때 기능 추가 할 예정


### 2. 이미지 추가

presigned URL 로 이미지 추가하고 S3 서버에 올리는거 확인했습니다
이미지 추가하고 띄우는걸 다음번까지 목표로 할게요


### 3. API에 맞춘 페이지네이션 컴포넌트 리팩토링

지금 현재 페이지네이션 컴포넌트가 수정이 필요합니다
저희가 사용했던 더미데이터 방식과 API 에서 넘겨주는 데이터가 달라서
NewPagination.jsx로 새로 파일을 만들어둘테니 다 완성되면 또 그때 가서 설명드릴게요


### 4. Pagination에 맞춘 로직 변경

지금 현재 api 연동은 page 반영을 안했고, 뒤에 page 쿼리도 안붙여놓은 상태라 수정이 필요합니다


### 5. 홈페이지 API 연동

홈페이지는 일단 따로 더 api를 추가하기보다는 제가 다른데서 알아서 끌고와서 구현하기로 했습니다
아마 데이터중 랜덤이나 앞에서부터 차례대로 보여주는 형식대로 할거 같긴합니다


### 6. Favorite 장르, 해시태그 등 스키마 제작

하나의 스키마로 돌려쓰는게 아무래도 재사용성이 좋을거같아서 만들어둘 예정인데
아마 그때쯤에는 다들 만들어뒀을거같긴하네요

---

## 💬 리뷰 요구 사항

1. 커뮤니티 css 깨진다고 했던거 수정햇습니다 한번만 확인해주세용