### PR TITLE
fix: 모바일 환경에서 레이아웃 오른쪽 여백 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "crypto-js": "^4.2.0",
         "date-fns": "^4.1.0",
         "history": "^5.3.0",
+        "motion": "^12.23.12",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.1.1",
@@ -7857,6 +7858,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -10676,6 +10704,47 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.12.tgz",
+      "integrity": "sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.12",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
     "history": "^5.3.0",
+    "motion": "^12.23.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.1",

--- a/src/components/topbar/TopbarMenuMobile.tsx
+++ b/src/components/topbar/TopbarMenuMobile.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { MENU } from './Topbar';
 import Beta from '../../assets/beta.svg';
+import { AnimatePresence, motion } from 'motion/react';
 
 interface TopbarMenuMobileProps {
   visible: boolean;
@@ -10,19 +11,29 @@ interface TopbarMenuMobileProps {
 
 const TopbarMenuMobile = ({ visible, onClose }: TopbarMenuMobileProps) => {
   return (
-    <>
-      {visible && <Overlay onClick={onClose} />}
-      <MenuContainer className={visible ? 'visible' : ''}>
-        {MENU.map((menu) => (
-          <MenuWrapper key={menu.path}>
-            <MenuLabel to={menu.path} onClick={onClose}>
-              <span>{menu.label}</span>
-            </MenuLabel>
-            {menu.isBeta && <BetaLabel src={Beta} alt="BETA 라벨" />}
-          </MenuWrapper>
-        ))}
-      </MenuContainer>
-    </>
+    <AnimatePresence>
+      {visible && (
+        <>
+          <Overlay onClick={onClose} />
+          <MenuContainer
+            as={motion.div}
+            initial={{ opacity: 0, x: '100%' }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: '100%' }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+          >
+            {MENU.map((menu) => (
+              <MenuWrapper key={menu.path}>
+                <MenuLabel to={menu.path} onClick={onClose}>
+                  <span>{menu.label}</span>
+                </MenuLabel>
+                {menu.isBeta && <BetaLabel src={Beta} alt="BETA 라벨" />}
+              </MenuWrapper>
+            ))}
+          </MenuContainer>
+        </>
+      )}
+    </AnimatePresence>
   );
 };
 
@@ -49,19 +60,6 @@ const MenuContainer = styled.div`
   background-color: black;
   border-radius: 10px 0 0 10px;
   box-shadow: 0px 0px 10px var(--main-purple);
-
-  opacity: 0;
-  transform: translateX(100%);
-  transition:
-    opacity 0.3s ease,
-    transform 0.3s ease;
-  pointer-events: none;
-
-  &.visible {
-    opacity: 1;
-    transform: translateX(0);
-    pointer-events: auto;
-  }
 `;
 const MenuWrapper = styled.div`
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Pretendard, sans-serif;
+  font-family: --apple-system, BlinkMacSystemFont, Pretendard, sans-serif;
   font-display: swap;
   font-style: normal;
   line-height: normal;
@@ -29,5 +29,6 @@ body {
 }
 
 * {
+  margin: 0;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## 💡 연관된 이슈
closed #195

## 📝 작업 내용
모바일용 Topbar 메뉴 컴포넌트(`TopbarMenuMobile.tsx`)의 오른쪽 여백 문제를 해결했습니다.
- [x] `motion` 라이브러리 dependency 추가
- [x] `motion`의 `AnimatePresence`를 사용하여 모바일 메뉴의 슬라이드 애니메이션 전후로 DOM 제거
- [x] `visible=false` 시 DOM에서 메뉴가 제거되도록 수정하여 모바일 화면에서 불필요한 오른쪽 여백 제거
- [x] 기존 슬라이드 인/아웃 애니메이션은 그대로 유지
