### PR TITLE
feat: 수업 예약 페이지 날짜/요일별 조회 API 수정 및 일부 디자인 QA 반영

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "danthis",
       "version": "0.1.0",
       "dependencies": {
-        "@tanstack/react-query": "^5.66.0",
+        "@tanstack/react-query": "^5.89.0",
         "axios": "^1.7.9",
         "cra-template": "1.2.0",
         "crypto": "^1.0.1",
@@ -25,7 +25,7 @@
         "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.13",
         "web-vitals": "^4.2.4",
-        "zustand": "^5.0.2"
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -3282,21 +3282,20 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.66.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.66.0.tgz",
-      "integrity": "sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==",
-      "license": "MIT",
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.89.0.tgz",
+      "integrity": "sha512-joFV1MuPhSLsKfTzwjmPDrp8ENfZ9N23ymFu07nLfn3JCkSHy0CFgsyhHTJOmWaumC/WiNIKM0EJyduCF/Ih/Q==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.66.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.66.0.tgz",
-      "integrity": "sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==",
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.89.0.tgz",
+      "integrity": "sha512-SXbtWSTSRXyBOe80mszPxpEbaN4XPRUp/i0EfQK1uyj3KCk/c8FuPJNIRwzOVe/OU3rzxrYtiNabsAmk1l714A==",
       "dependencies": {
-        "@tanstack/query-core": "5.66.0"
+        "@tanstack/query-core": "5.89.0"
       },
       "funding": {
         "type": "github",
@@ -16535,9 +16534,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.2.tgz",
-      "integrity": "sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
       "engines": {
         "node": ">=12.20.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.89.0",
+        "@tanstack/react-query-devtools": "^5.89.0",
         "axios": "^1.7.9",
         "cra-template": "1.2.0",
         "crypto": "^1.0.1",
@@ -3290,6 +3291,16 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.87.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.87.3.tgz",
+      "integrity": "sha512-LkzxzSr2HS1ALHTgDmJH5eGAVsSQiuwz//VhFW5OqNk0OQ+Fsqba0Tsf+NzWRtXYvpgUqwQr4b2zdFZwxHcGvg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.89.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.89.0.tgz",
@@ -3302,6 +3313,23 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.89.0.tgz",
+      "integrity": "sha512-Syc4UjZeIJCkXCRGyQcWwlnv89JNb98MMg/DAkFCV3rwOcknj98+nG3Nm6xLXM6ne9sK6RZeDJMPLKZUh6NUGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.87.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.89.0",
         "react": "^18 || ^19"
       }
     },
@@ -16537,6 +16565,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
       "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@tanstack/react-query": "^5.89.0",
+    "@tanstack/react-query-devtools": "^5.89.0",
     "axios": "^1.7.9",
     "cra-template": "1.2.0",
     "crypto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@tanstack/react-query": "^5.66.0",
+    "@tanstack/react-query": "^5.89.0",
     "axios": "^1.7.9",
     "cra-template": "1.2.0",
     "crypto": "^1.0.1",
@@ -20,7 +20,7 @@
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.13",
     "web-vitals": "^4.2.4",
-    "zustand": "^5.0.2"
+    "zustand": "^5.0.8"
   },
   "engines": {
     "node": "22.x"

--- a/src/api/reservation.ts
+++ b/src/api/reservation.ts
@@ -1,6 +1,7 @@
 import api from './api';
 import { PaginationParams } from '../types/common';
 import {
+  GetClassesAllDto,
   ResponseChat,
   ResponseClassDetail,
   ResponseClasses,
@@ -12,9 +13,9 @@ import {
   ResponseReview
 } from '../types/reservation';
 
-export const fetchClasses = async (paginationParams: PaginationParams): Promise<ResponseClasses> => {
+export const fetchClasses = async (params: GetClassesAllDto): Promise<ResponseClasses> => {
   const { data } = await api.get(`/dance-classes/all`, {
-    params: paginationParams
+    params
   });
   return data;
 };

--- a/src/common/DancerProfile/ClassTab.tsx
+++ b/src/common/DancerProfile/ClassTab.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import {useNavigate} from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Pagination from '../../components/Pagination';
 import { useParams } from 'react-router-dom';
 import api from '../../api/api';
 import axiosInstance from '../../api/axios-instance';
-
 
 type DanceClassType = {
   id: number;
@@ -60,11 +59,7 @@ const ClassTab: React.FC<Props> = ({ dancerId }) => {
       <ClassContainer hasClasses={classes.length > 0}>
         {classes.length > 0 ? (
           classes.map((item) => (
-            <Class 
-            key={item.id}
-            onClick={() => navigate(`/classreservation/${item.id}`)}
-              style={{ cursor: 'pointer' }} 
-              >
+            <Class key={item.id} onClick={() => navigate(`/classes/${item.id}`)} style={{ cursor: 'pointer' }}>
               <ClassImg src={item.thumbnailImage} alt={item.className} />
             </Class>
           ))
@@ -106,10 +101,8 @@ const ClassContainer = styled.div<{ hasClasses: boolean }>`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 10px;
-  display: ${({ hasClasses }) =>
-    hasClasses ? 'grid' : 'flex'}; // 수업이 없을 때 flex로 변경
-  grid-template-columns: ${({ hasClasses }) =>
-    hasClasses ? 'repeat(3, 1fr)' : 'none'};
+  display: ${({ hasClasses }) => (hasClasses ? 'grid' : 'flex')}; // 수업이 없을 때 flex로 변경
+  grid-template-columns: ${({ hasClasses }) => (hasClasses ? 'repeat(3, 1fr)' : 'none')};
   ${({ theme }) => theme.media.tablet} {
     gap: 55px;
   }

--- a/src/common/Home/ForClass.tsx
+++ b/src/common/Home/ForClass.tsx
@@ -18,10 +18,7 @@ const ForClass = ({ danceclass }: ForClassProps) => {
   return (
     <ClassContainer>
       {randomDance?.map((Class) => (
-        <ClassContent
-          key={Class.id}
-          onClick={() => navigate(`/classreservation/${Class.id}?tab=detail`)}
-        >
+        <ClassContent key={Class.id} onClick={() => navigate(`/classes/${Class.id}?tab=detail`)}>
           <ClassImage src={Class.thumbnailImage} alt="프로필 이미지" />
           <TextContainer>
             <ClassName>{Class.className}</ClassName>
@@ -29,14 +26,8 @@ const ForClass = ({ danceclass }: ForClassProps) => {
             <ClassDancer>{Class.favoriteGenres}</ClassDancer>
             <ClassHashContainer>
               {Class.hashtagIds.map((HashtagID) => {
-                const foundTag = hashTagID.find(
-                  (tag) => tag.id === String(HashtagID)
-                );
-                return foundTag ? (
-                  <ClassHashtag key={HashtagID}>
-                    # {foundTag.hashTag}
-                  </ClassHashtag>
-                ) : null;
+                const foundTag = hashTagID.find((tag) => tag.id === String(HashtagID));
+                return foundTag ? <ClassHashtag key={HashtagID}># {foundTag.hashTag}</ClassHashtag> : null;
               })}
             </ClassHashContainer>
           </TextContainer>

--- a/src/common/Home/PassiveCarousel.tsx
+++ b/src/common/Home/PassiveCarousel.tsx
@@ -33,10 +33,7 @@ const PassiveCarousel = ({ danceclass }: PassiveCarouselProps) => {
   }, [isMobile, danceclass?.danceClasses?.length]);
 
   useEffect(() => {
-    const maxStart = Math.max(
-      0,
-      (danceclass?.danceClasses?.length ?? 0) - VISIBLE
-    );
+    const maxStart = Math.max(0, (danceclass?.danceClasses?.length ?? 0) - VISIBLE);
     if (currentIndex > maxStart) setCurrentIndex(maxStart);
   }, [VISIBLE, danceclass?.danceClasses?.length, currentIndex]);
 
@@ -49,30 +46,20 @@ const PassiveCarousel = ({ danceclass }: PassiveCarouselProps) => {
 
   return (
     <SliderContainer $gutter={GUTTER}>
-      <ClickArea
-        $side="left"
-        $gutter={GUTTER}
-        $disabled={!canPrev}
-        onClick={handlePrev}
-      />
+      <ClickArea $side="left" $gutter={GUTTER} $disabled={!canPrev} onClick={handlePrev} />
       <SlideWrapper $offset={currentIndex * step}>
         {danceclass?.danceClasses?.map((item, index) => (
           <HotImage
             ref={index === 0 ? firstCardRef : undefined}
             key={item.id ?? index}
-            onClick={() => navigate(`/classreservation/${item.id}?tab=detail`)}
+            onClick={() => navigate(`/classes/${item.id}?tab=detail`)}
             src={item.thumbnailImage}
             alt="Image"
             $visible={index >= currentIndex && index < currentIndex + VISIBLE}
           />
         ))}
       </SlideWrapper>
-      <ClickArea
-        $side="right"
-        $gutter={GUTTER}
-        $disabled={!canNext}
-        onClick={handleNext}
-      />
+      <ClickArea $side="right" $gutter={GUTTER} $disabled={!canNext} onClick={handleNext} />
     </SliderContainer>
   );
 };

--- a/src/common/reservation/ClassesGrid.tsx
+++ b/src/common/reservation/ClassesGrid.tsx
@@ -45,6 +45,10 @@ export const ClassesGrid = ({ selectedGenre }: ClassesGridProps) => {
               </TextContainer>
             </Class>
           ))}
+
+          {Array.from({ length: SIZE - classes.danceClasses.length }).map((_, i) => (
+            <ClassPlaceholder key={`placeholder-${i}`} />
+          ))}
         </Classes>
       ) : (
         <NoClass>등록된 수업이 없습니다.</NoClass>
@@ -70,14 +74,13 @@ const GridContainer = styled.div`
   justify-content: flex-start;
   width: 100%;
   height: 100%;
-  // min-height: 578px;
+  min-height: 578px;
 
   ${({ theme }) => theme.media.desktop} {
     padding-top: 24px;
   }
 `;
 const Classes = styled.div`
-  // flex: 1;
   width: 100%;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -143,6 +146,15 @@ const NoClass = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 208px 0;
   text-align: center;
   color: var(--text-secondary-gray);
+`;
+const ClassPlaceholder = styled.div`
+  width: 100%;
+  padding: 97px 0;
+  aspect-ratio: 1 / 1;
+  border-radius: 10px;
+  background: transparent;
+  pointer-events: none;
 `;

--- a/src/common/reservation/ClassesGrid.tsx
+++ b/src/common/reservation/ClassesGrid.tsx
@@ -131,8 +131,8 @@ const Dancer = styled.div`
   width: 100%;
   text-align: center;
   color: var(--text-secondary-gray);
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 400;
   letter-spacing: -0.8px;
   white-space: nowrap;
   overflow: hidden;

--- a/src/common/reservation/DateTypeToggle.tsx
+++ b/src/common/reservation/DateTypeToggle.tsx
@@ -36,7 +36,7 @@ const ToggleButton = styled.button<{ $isActive: boolean }>`
   align-items: center;
   justify-content: center;
   padding: ${({ $isActive }) => ($isActive ? '6px 8px' : '4px 8px')};
-  gap: 8px;
+  gap: 4px;
   border: none;
   border-radius: 999px;
   background-color: ${({ $isActive }) => ($isActive ? 'var(--main-purple)' : 'transparent')};
@@ -47,13 +47,13 @@ const ToggleButton = styled.button<{ $isActive: boolean }>`
   font-size: 14px;
   font-weight: 600;
   letter-spacing: -0.7px;
+  line-height: 0.9;
 
   svg {
     width: 24px;
     height: 24px;
     fill: ${({ $isActive }) => ($isActive ? 'var(--main-white)' : 'var(--text-gray)')};
     transition: fill 0.2s ease-in-out;
-    margin-top: 2px;
   }
 
   ${({ theme }) => theme.media.tablet} {

--- a/src/common/reservation/DateTypeToggle.tsx
+++ b/src/common/reservation/DateTypeToggle.tsx
@@ -10,7 +10,7 @@ export const DateTypeToggle = () => {
 
   return (
     <ToggleWrapper>
-      <ToggleButton $isActive={selectedType === DATE_TYPE.DATE} onClick={() => setSelectedType(DATE_TYPE.DATE)}>
+      <ToggleButton $isActive={selectedType === DATE_TYPE.DAILY} onClick={() => setSelectedType(DATE_TYPE.DAILY)}>
         <Calendar />
         날짜
       </ToggleButton>

--- a/src/common/reservation/DateTypeToggle.tsx
+++ b/src/common/reservation/DateTypeToggle.tsx
@@ -1,21 +1,20 @@
 import styled from 'styled-components';
 import { ReactComponent as Weekly } from '../../assets/reservation/Weekly.svg';
 import { ReactComponent as Calendar } from '../../assets/reservation/Calendar.svg';
-import { DATE_TYPE, DateType } from '../../types/reservation';
+import { DATE_TYPE } from '../../types/reservation';
+import { useDateSelectionStore } from '../../store/dateSelectionStore';
 
-interface DateTypeToggleProps {
-  selectedType: DateType;
-  setSelectType: (type: DateType) => void;
-}
+export const DateTypeToggle = () => {
+  const selectedType = useDateSelectionStore((store) => store.type);
+  const setSelectedType = useDateSelectionStore((store) => store.setType);
 
-export const DateTypeToggle = ({ selectedType, setSelectType }: DateTypeToggleProps) => {
   return (
     <ToggleWrapper>
-      <ToggleButton $isActive={selectedType === DATE_TYPE.DATE} onClick={() => setSelectType(DATE_TYPE.DATE)}>
+      <ToggleButton $isActive={selectedType === DATE_TYPE.DATE} onClick={() => setSelectedType(DATE_TYPE.DATE)}>
         <Calendar />
         날짜
       </ToggleButton>
-      <ToggleButton $isActive={selectedType === DATE_TYPE.WEEKLY} onClick={() => setSelectType(DATE_TYPE.WEEKLY)}>
+      <ToggleButton $isActive={selectedType === DATE_TYPE.WEEKLY} onClick={() => setSelectedType(DATE_TYPE.WEEKLY)}>
         <Weekly />
         요일
       </ToggleButton>

--- a/src/common/reservation/SelectionPanel.tsx
+++ b/src/common/reservation/SelectionPanel.tsx
@@ -1,16 +1,17 @@
-import { useState } from 'react';
 import styled from 'styled-components';
 import { DateTypeToggle } from './DateTypeToggle';
-import { DATE_TYPE, DateType } from '../../types/reservation';
+import { DATE_TYPE, DAYS_OF_WEEK } from '../../types/reservation';
 import CustomCalendar from '../../components/Calendar';
-import { DAYS_OF_WEEK, WeeklySelector } from './WeeklySelector';
+import { WeeklySelector } from './WeeklySelector';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { useDateSelectionStore } from '../../store/dateSelectionStore';
 
 export const SelectionPanel = () => {
-  const [selectedType, setSelectedType] = useState<DateType>(DATE_TYPE.DATE);
-  const [selectedDayKey, setSelectedDayKey] = useState<string>('MON');
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const selectedType = useDateSelectionStore((store) => store.type);
+  const selectedDayKey = useDateSelectionStore((store) => store.day);
+  const selectedDate = useDateSelectionStore((store) => store.date);
+  const setSelectedDate = useDateSelectionStore((store) => store.setDate);
 
   const selectedDayName = DAYS_OF_WEEK.find((day) => day.key === selectedDayKey)?.ko;
   const formattedDate = format(selectedDate, 'yyyy. MM. dd (E)', {
@@ -20,7 +21,7 @@ export const SelectionPanel = () => {
   return (
     <PanelContainer>
       <PanelHeader>
-        <DateTypeToggle selectedType={selectedType} setSelectType={setSelectedType} />
+        <DateTypeToggle />
         <SelectedDate>
           선택:
           <DateText>{selectedType === DATE_TYPE.DATE ? formattedDate : selectedDayName}</DateText>
@@ -28,7 +29,7 @@ export const SelectionPanel = () => {
       </PanelHeader>
 
       {selectedType === DATE_TYPE.DATE && <CustomCalendar selectedDate={selectedDate} onDateClick={setSelectedDate} />}
-      {selectedType === DATE_TYPE.WEEKLY && <WeeklySelector dayKey={selectedDayKey} setDayKey={setSelectedDayKey} />}
+      {selectedType === DATE_TYPE.WEEKLY && <WeeklySelector />}
     </PanelContainer>
   );
 };

--- a/src/common/reservation/SelectionPanel.tsx
+++ b/src/common/reservation/SelectionPanel.tsx
@@ -69,7 +69,7 @@ const SelectedDate = styled.p`
 const DateText = styled.span`
   margin-left: 7px;
   color: var(--main-white);
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 500;
   letter-spacing: -0.6px;
 

--- a/src/common/reservation/SelectionPanel.tsx
+++ b/src/common/reservation/SelectionPanel.tsx
@@ -24,11 +24,11 @@ export const SelectionPanel = () => {
         <DateTypeToggle />
         <SelectedDate>
           선택:
-          <DateText>{selectedType === DATE_TYPE.DATE ? formattedDate : selectedDayName}</DateText>
+          <DateText>{selectedType === DATE_TYPE.DAILY ? formattedDate : selectedDayName}</DateText>
         </SelectedDate>
       </PanelHeader>
 
-      {selectedType === DATE_TYPE.DATE && <CustomCalendar selectedDate={selectedDate} onDateClick={setSelectedDate} />}
+      {selectedType === DATE_TYPE.DAILY && <CustomCalendar selectedDate={selectedDate} onDateClick={setSelectedDate} />}
       {selectedType === DATE_TYPE.WEEKLY && <WeeklySelector />}
     </PanelContainer>
   );

--- a/src/common/reservation/WeeklySelector.tsx
+++ b/src/common/reservation/WeeklySelector.tsx
@@ -1,25 +1,15 @@
+import { useDateSelectionStore } from '../../store/dateSelectionStore';
+import { Day, DAYS_OF_WEEK } from '../../types/reservation';
 import styled from 'styled-components';
-
-export const DAYS_OF_WEEK = [
-  { key: 'MON', ko: '월' },
-  { key: 'TUE', ko: '화' },
-  { key: 'WED', ko: '수' },
-  { key: 'THU', ko: '목' },
-  { key: 'FRI', ko: '금' },
-  { key: 'SAT', ko: '토' },
-  { key: 'SUN', ko: '일' }
-];
 
 const firstRowDays = DAYS_OF_WEEK.slice(0, 4); // 월, 화, 수, 목
 const secondRowDays = DAYS_OF_WEEK.slice(4); // 금, 토, 일
 
-interface WeeklySelectorProps {
-  dayKey: string;
-  setDayKey: (value: string) => void;
-}
+export const WeeklySelector = () => {
+  const dayKey = useDateSelectionStore((store) => store.day);
+  const setDayKey = useDateSelectionStore((store) => store.setDay);
 
-export const WeeklySelector = ({ dayKey, setDayKey }: WeeklySelectorProps) => {
-  const handleSelectWeek = (dayKey: string) => setDayKey(dayKey);
+  const handleSelectWeek = (day: Day) => setDayKey(day);
 
   return (
     <DayButtonsWrapper>

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -55,8 +55,10 @@ const CustomCalendar = ({ selectedDate, onDateClick }: CalendarProps) => {
       </Header>
 
       <WeekDays>
-        {WEEK.map((day) => (
-          <div key={day}>{day}</div>
+        {WEEK.map((day, idx) => (
+          <WeekDay key={day} $dayOfWeek={idx}>
+            {day}
+          </WeekDay>
         ))}
       </WeekDays>
 
@@ -115,10 +117,16 @@ const WeekDays = styled.div`
   padding-bottom: 16px;
   margin-bottom: 16px;
   border-bottom: 1px solid var(--main-white);
-
+`;
+const WeekDay = styled.div<{ $dayOfWeek: number }>`
   font-size: 16px;
   font-weight: 400;
   line-height: 140%;
+  color: ${({ $dayOfWeek }) => {
+    if ($dayOfWeek === 0) return 'var(--highlight-red)';
+    if ($dayOfWeek === 6) return 'var(--highlight-blue)';
+    return 'var(--main-white)';
+  }};
 `;
 const DaysGrid = styled.div`
   display: grid;

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -36,8 +36,8 @@ const shimmer = keyframes`
 `;
 
 const baseStyle = css<SkeletonProps>`
-  --sk-base: ${({ baseColor }) => baseColor ?? '#222'};
-  --sk-highlight: ${({ highlightColor }) => highlightColor ?? '#333'};
+  --sk-base: ${({ baseColor }) => baseColor ?? '#111'};
+  --sk-highlight: ${({ highlightColor }) => highlightColor ?? '#222'};
 
   position: relative;
   overflow: hidden;

--- a/src/hooks/reservation/useGetClasses.ts
+++ b/src/hooks/reservation/useGetClasses.ts
@@ -1,11 +1,11 @@
+import { GetClassesAllDto } from '../../types/reservation';
 import { fetchClasses } from '../../api/reservation';
-import { PaginationParams } from '../../types/common';
 import { useQuery } from '@tanstack/react-query';
 
-export default function useGetClasses({ genre, page, size }: PaginationParams) {
+export default function useGetClasses({ genre, page, size, day }: GetClassesAllDto) {
   return useQuery({
-    queryKey: ['classes', genre, page, size],
-    queryFn: () => fetchClasses({ genre, page, size }),
+    queryKey: ['classes', genre, page, size, day],
+    queryFn: () => fetchClasses({ genre, page, size, day }),
     staleTime: 1000 * 60 * 5, // 5분
     gcTime: 1000 * 60 * 10, // 10분
     select: (data) => data.data

--- a/src/hooks/reservation/useGetClasses.ts
+++ b/src/hooks/reservation/useGetClasses.ts
@@ -2,10 +2,10 @@ import { GetClassesAllDto } from '../../types/reservation';
 import { fetchClasses } from '../../api/reservation';
 import { useQuery } from '@tanstack/react-query';
 
-export default function useGetClasses({ genre, page, size, day }: GetClassesAllDto) {
+export default function useGetClasses({ genre, page, size, day, date }: GetClassesAllDto) {
   return useQuery({
-    queryKey: ['classes', genre, page, size, day],
-    queryFn: () => fetchClasses({ genre, page, size, day }),
+    queryKey: ['classes', genre, page, size, day, date],
+    queryFn: () => fetchClasses({ genre, page, size, day, date }),
     staleTime: 1000 * 60 * 5, // 5분
     gcTime: 1000 * 60 * 10, // 10분
     select: (data) => data.data

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,9 @@ body {
   --text-purple: #bf00ff;
   --text-gray: #4d4d4d;
   --text-secondary-gray: #b2b2b2;
+
+  --highlight-red: #f00;
+  --highlight-blue: #07f;
 }
 
 * {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ThemeProvider } from 'styled-components';
 import { theme } from './theme';
 
@@ -21,6 +22,8 @@ root.render(
       <ThemeProvider theme={theme}>
         <App />
       </ThemeProvider>
+
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/pages/reservation/ReservationPage.tsx
+++ b/src/pages/reservation/ReservationPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import useGetClassDetailById from '../../hooks/reservation/useGetClassDetailById';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import { ClassSummary, DetailTab, RatingTab, ReviewTab } from '../../common/reservation';
+import { ScrollToTop } from '../../components/ScrollToTop';
 
 export default function ReservationPage() {
   const navigate = useNavigate();
@@ -39,6 +40,8 @@ export default function ReservationPage() {
 
   return (
     <Container>
+      <ScrollToTop />
+
       <LoadingSpinner isLoading={isLoading} marginTop="180px" marginBottom="180px">
         <ClassSummary classId={classId!} classData={classData!} />
       </LoadingSpinner>

--- a/src/store/dateSelectionStore.ts
+++ b/src/store/dateSelectionStore.ts
@@ -11,7 +11,7 @@ interface DateSelectionState {
 }
 
 export const useDateSelectionStore = create<DateSelectionState>((set) => ({
-  type: DATE_TYPE.DATE,
+  type: DATE_TYPE.DAILY,
   day: DAYS_OF_WEEK[0].key,
   date: new Date(),
   setType: (newType) => set({ type: newType }),

--- a/src/store/dateSelectionStore.ts
+++ b/src/store/dateSelectionStore.ts
@@ -1,0 +1,20 @@
+import { DATE_TYPE, DateType, Day, DAYS_OF_WEEK } from '../types/reservation';
+import { create } from 'zustand';
+
+interface DateSelectionState {
+  type: DateType;
+  day: Day;
+  date: Date;
+  setType: (type: DateType) => void;
+  setDay: (day: Day) => void;
+  setDate: (date: Date) => void;
+}
+
+export const useDateSelectionStore = create<DateSelectionState>((set) => ({
+  type: DATE_TYPE.DATE,
+  day: DAYS_OF_WEEK[0].key,
+  date: new Date(),
+  setType: (newType) => set({ type: newType }),
+  setDay: (newDay) => set({ day: newDay }),
+  setDate: (newDate) => set({ date: newDate })
+}));

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -12,8 +12,14 @@ export type OffsetBasedResponse<K extends string, T> = CommonResponse<
   } & Record<K, T>
 >;
 
-export type PaginationParams = {
+// TODO: 수정 필요 -> CommonPagination 이용
+export interface PaginationParams {
   genre?: number;
   page?: number;
   size?: number;
-};
+}
+
+export interface CommonPagination {
+  page?: number;
+  size?: number;
+}

--- a/src/types/reservation.ts
+++ b/src/types/reservation.ts
@@ -10,7 +10,7 @@ import { CommonPagination, CommonResponse, OffsetBasedResponse } from './common'
 
 export const DATE_TYPE = {
   WEEKLY: 'WEEKLY',
-  DATE: 'DATE'
+  DAILY: 'DAILY'
 } as const;
 
 export type DateType = (typeof DATE_TYPE)[keyof typeof DATE_TYPE];

--- a/src/types/reservation.ts
+++ b/src/types/reservation.ts
@@ -6,7 +6,7 @@ import {
   SimpleDanceClass,
   SingleReview
 } from './class';
-import { CommonResponse, OffsetBasedResponse } from './common';
+import { CommonPagination, CommonResponse, OffsetBasedResponse } from './common';
 
 export const DATE_TYPE = {
   WEEKLY: 'WEEKLY',
@@ -14,6 +14,18 @@ export const DATE_TYPE = {
 } as const;
 
 export type DateType = (typeof DATE_TYPE)[keyof typeof DATE_TYPE];
+
+export const DAYS_OF_WEEK = [
+  { key: 'MON', ko: '월' },
+  { key: 'TUE', ko: '화' },
+  { key: 'WED', ko: '수' },
+  { key: 'THU', ko: '목' },
+  { key: 'FRI', ko: '금' },
+  { key: 'SAT', ko: '토' },
+  { key: 'SUN', ko: '일' }
+] as const;
+
+export type Day = (typeof DAYS_OF_WEEK)[number]['key'];
 
 export type ResponseClasses = OffsetBasedResponse<'danceClasses', SimpleDanceClass[]>;
 export type ResponseClassDetail = CommonResponse<DanceClassDetail>;
@@ -33,3 +45,10 @@ export type ResponseMyLiked = OffsetBasedResponse<'danceClasses', LikedClass[]>;
 // review
 export type ResponseReview = CommonResponse<SingleReview>;
 export type ResponseDeleteReview = CommonResponse<null>;
+
+// 댄스 수업 목록 조회
+export interface GetClassesAllDto extends CommonPagination {
+  genre?: number;
+  day?: string;
+  date?: string;
+}


### PR DESCRIPTION
## 💡 연관된 이슈

#197 날짜/요일별 댄스 수업 조회 기능 API 연동
#211 수업 예약 - 달력 수정

## 📝 작업 내용

- [x] `zustand`, `react-query-devtools` 의존성 추가
- [x] 날짜 선택 상태를 전역 상태로 관리하도록 변경
- [x] 수업 목록 조회 API 변경에 따라, 날짜/요일 파라미터를 받도록 관련 파일 수정(apis, hooks)
- [x] 수업이 없는 경우를 고려하여 그리드 여백 스타일 수정 및 문구 처리
\
- [x] 메인 페이지 캐러셀에서 특정 댄서 -> 수업 경로 불일치로 인한 블랙 스크린 문제 해결 
- 이 부분에서 캐러셀에서 수업 예약 페이지로 이동했을 때 스크롤 위치가 `top`으로 안되어 있는 문제가 있어서 `ScrollToTop` 공용 컴포넌트로 만들고 적용함
\
- [x] QA - 캘린더 토요일, 일요일 색상 다르게 수정
- [x] QA - 날짜 선택 패널에서 선택: 다음 부분 크기 늘림
- [x] QA - 수업 그리드 댄서 네임 폰트 size/weight 줄임

<img width="1197" height="597" alt="image" src="https://github.com/user-attachments/assets/2e0bef83-3801-469c-b2e7-bb73c88a8ea1" />

<img width="1146" height="605" alt="image" src="https://github.com/user-attachments/assets/4e340e25-219f-4e38-beea-e477736239a0" />
